### PR TITLE
Adjust assets:install command to use web/ folder instead of public/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 
 before_script:
     - (cd tests/Application && bin/console doctrine:schema:create --env=test)
-    - (cd tests/Application && bin/console assets:install --env=test)
+    - (cd tests/Application && bin/console assets:install web --env=test)
     #- (cd tests/Application && yarn run gulp)
 
     - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1680x1050x16


### PR DESCRIPTION
In one of my plugins Travis errored on this line after upgrading to Symfony 3.3. It seems Symfony 3.3 (looking at the `assets:install` code) now uses the `public/` folder as default target folder, while Sylius is using `web/`. This PR uses the `web/` folder as target.

> $ (mkdir tests/Application/web && cd tests/Application && bin/console assets:install --env=test)
>                                                  
>   [InvalidArgumentException]                     
>   The target directory "public" does not exist.  
>                                                  
> assets:install [--symlink] [--relative] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command> [<target>]
> The command "(mkdir tests/Application/web && cd tests/Application && bin/console assets:install --env=test)" failed and exited with 1 during .