### PR TITLE
Revert "Added dev mode to the plugin skeleton"

### DIFF
--- a/tests/Application/app/AppKernel.php
+++ b/tests/Application/app/AppKernel.php
@@ -28,6 +28,6 @@ final class AppKernel extends Kernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
-        $loader->load($this->getRootDir() . '/config/config_' . $this->environment . '.yml');
+        $loader->load($this->getRootDir() . '/config/config.yml');
     }
 }

--- a/tests/Application/app/config/config_dev.yml
+++ b/tests/Application/app/config/config_dev.yml
@@ -4,13 +4,3 @@ imports:
 doctrine:
     dbal:
         path: "%kernel.root_dir%/../var/db_dev.sql"
-
-web_profiler:
-  toolbar: true
-  intercept_redirects: false
-
-framework:
-    router:
-        resource: "%kernel.root_dir%/config/routing_dev.yml"
-    profiler:
-        enabled: true

--- a/tests/Application/app/config/routing_dev.yml
+++ b/tests/Application/app/config/routing_dev.yml
@@ -1,2 +1,0 @@
-sylius:
-    resource: "../../../../vendor/sylius/sylius/app/config/routing_dev.yml"


### PR DESCRIPTION
Reverts Sylius/PluginSkeleton#97

I've forgotten that we've three branches on this repo as well, and this one should be open to the lowest one and the propagated up. 