### PR TITLE
Move vendor binaries to "vendor/bin/"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-/bin/*
-!/bin/.gitkeep
-
 /vendor/
 /node_modules/
 /composer.lock

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,5 @@
         "branch-alias": {
             "dev-master": "1.3-dev"
         }
-    },
-    "config": {
-        "bin-dir": "bin"
     }
 }


### PR DESCRIPTION
It is the default convention used in Symfony, it'd smooth the Sylius learning curve.