### PR TITLE
Require Fob/PageObjectExtension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "behat/mink-selenium2-driver": "^1.3",
         "friends-of-behat/context-service-extension": "^1.2",
         "friends-of-behat/cross-container-extension": "^1.1",
+        "friends-of-behat/page-object-extension": "^0.2.0",
         "friends-of-behat/service-container-extension": "^1.0",
         "friends-of-behat/symfony-extension": "^1.2.1",
         "friends-of-behat/variadic-extension": "^1.1",


### PR DESCRIPTION
As it's also used in Sylius and Sylius-Standard