### PR TITLE
Fixes tests/Application .gitignore

### DIFF
--- a/tests/Application/.gitignore
+++ b/tests/Application/.gitignore
@@ -5,7 +5,9 @@
 /public/bundles
 /public/css
 /public/js
-/public/media
+/public/media/*
+!/public/media/image/
+/public/media/image/*
 !/public/media/image/.gitignore
 
 /vendor


### PR DESCRIPTION
The `tests/Application/public/media/image/.gitignore` file has been probably added to the index with a force add (`git add -f`) because the parent `.gitignore` file (the one in `tests/Application`) doesn't properly de-ignore it.
So when someone creates a new plugin from this skeleton the `tests/Application/public/media/image/.gitignore` file is not added to index and the build fails (the `tests/Application/public/media/image/` must exists) otherwise you'll get the error:
```
[Liip\ImagineBundle\Exception\InvalidArgumentException]                                                                 
  Root image path not resolvable ...
```