### PR TITLE
Add support for PHP 7.3 & remove fake Symfony builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: false
 
 php:
     - 7.2
+    - 7.3
 
 cache:
     yarn: true
@@ -17,9 +18,6 @@ env:
     global:
         - SYLIUS_CACHE_DIR=$HOME/.sylius-cache
         - SYLIUS_BUILD_DIR=etc/build
-    matrix:
-        - SYMFONY_VERSION="3.4.*"
-        - SYMFONY_VERSION="4.2.*"
 
 before_install:
     - phpenv config-rm xdebug.ini
@@ -31,12 +29,6 @@ before_install:
     - set -a && source tests/Application/.env.test && set +a
 
 install:
-    - composer require "symfony/browser-kit:${SYMFONY_VERSION}" --no-interaction --no-update
-    - composer require "symfony/debug-bundle:${SYMFONY_VERSION}" --no-interaction --no-update
-    - composer require "symfony/dotenv:${SYMFONY_VERSION}" --no-interaction --no-update
-    - composer require "symfony/intl:${SYMFONY_VERSION}" --no-interaction --no-update
-    - composer require "symfony/web-profiler-bundle:${SYMFONY_VERSION}" --no-interaction --no-update
-    - composer require "symfony/web-server-bundle:${SYMFONY_VERSION}" --no-interaction --no-update
     - composer install --no-interaction --prefer-dist
     - (cd tests/Application && yarn install)
 


### PR DESCRIPTION
Requiring dev Symfony packages still keeps others on the highest possible version.