### PR TITLE
Allow using SQLite in test environment

### DIFF
--- a/tests/Application/config/packages/test/doctrine.yaml
+++ b/tests/Application/config/packages/test/doctrine.yaml
@@ -1,0 +1,4 @@
+doctrine:
+    dbal:
+        charset: UTF8
+        url: '%env(resolve:DATABASE_URL)%'


### PR DESCRIPTION
First things first: 

1) Only `.env.test.dist` env is being parsed by Behat by default which might be confusing if someone uses `.env` for a test environment
2) Default global `doctrine.yaml` configuration forces you to use MySQL server only, but it's far better to use SQLite for plugins instead, especially if you're working on many plugins at the same time without Docker or Vagrant.

PS. Are you planning to write the test suite for plugin skeleton features? There's always a problem once you publish a new Sylius release 😢 . This kind of test suite could be also used to test Sylius-Standard.