### PR TITLE
Fix deprecation for symfony/config 4.2+

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,8 +14,13 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('acme_sylius_example_plugin');
+        $treeBuilder = new TreeBuilder('acme_sylius_example_plugin');
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('acme_sylius_example_plugin');
+        }
 
         return $treeBuilder;
     }


### PR DESCRIPTION
Fix deprecation for symfony/config 4.2

Fixed the same way as in https://github.com/symfony/maker-bundle/pull/324