### PR TITLE
[RFC][Maintenance] Remove phpstan symfony extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "phpspec/phpspec": "^5.0",
         "phpstan/phpstan-doctrine": "^0.10",
         "phpstan/phpstan-shim": "^0.10",
-        "phpstan/phpstan-symfony": "^0.10",
         "phpstan/phpstan-webmozart-assert": "^0.10",
         "phpunit/phpunit": "^6.5",
         "sensiolabs/security-checker": "^5.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,13 +1,9 @@
 includes:
     - vendor/phpstan/phpstan-doctrine/extension.neon
-    - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-webmozart-assert/extension.neon
 
 parameters:
     reportUnmatchedIgnoredErrors: false
-
-    symfony:
-        container_xml_path: tests/Application/var/cache/test/ApplicationTests_Acme_SyliusExamplePlugin_Application_KernelTestDebugContainer.xml
 
     excludes_analyse:
         # Makes PHPStan crash


### PR DESCRIPTION
My proposal is to remove symfony extention from our Plugin Skeleton. Main reasoning is that it adds another file, which has to be changed in order to make PluginSkeleton ready to be used for our community, while the benefit is not that big, if someone is following our best practices.