### PR TITLE
Add missing polishsymfonycommunity/symfony-mocker-container dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "symfony/dotenv": "^4.4 || ^5.2",
         "symfony/intl": "^4.4 || ^5.2",
         "symfony/web-profiler-bundle": "^4.4 || ^5.2",
-        "vimeo/psalm": "4.7.1"
+        "vimeo/psalm": "4.7.1",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0"
     },
     "config": {
         "sort-packages": true

--- a/tests/Application/Kernel.php
+++ b/tests/Application/Kernel.php
@@ -67,7 +67,7 @@ final class Kernel extends BaseKernel
 
     protected function getContainerBaseClass(): string
     {
-        if ($this->isTestEnvironment()) {
+        if ($this->isTestEnvironment() && class_exists(MockerContainer::class)) {
             return MockerContainer::class;
         }
 


### PR DESCRIPTION
Sylius 1.10.6 release has broken testing environments in the plugins based on PluginSkeleton.  [Moving `"polishsymfonycommunity/symfony-mocker-container"` to `require-dev`](https://github.com/Sylius/Sylius/commit/673bc6662c3934f3e5c1e8cfa0a3fc8710a437b1#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34) caused it's no longer available in PluginSkeleton so I've reproduced the steps from the commit to fix it.

