### PR TITLE
Adjust path in security.yaml for 1.10 to match behat tests

### DIFF
--- a/tests/Application/config/sylius/1.10/packages/security.yaml
+++ b/tests/Application/config/sylius/1.10/packages/security.yaml
@@ -2,7 +2,7 @@ parameters:
     sylius.security.admin_regex: "^/%sylius_admin.path_name%"
     sylius.security.api_regex: "^/api"
     sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|new-api|api/.*|api$|media/.*)[^/]++"
-    sylius.security.new_api_route: "/new-api"
+    sylius.security.new_api_route: "/api/v2"
     sylius.security.new_api_regex: "^%sylius.security.new_api_route%"
     sylius.security.new_api_admin_route: "%sylius.security.new_api_route%/admin"
     sylius.security.new_api_admin_regex: "^%sylius.security.new_api_admin_route%"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10+
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes (people expecting the API to be at /new-api in their old test will have their tests fail)
| Deprecations?   | no
| Related tickets | fixes #310
| License         | MIT

