### PR TITLE
Update security.yml with the latest Sylius-Standard one

### DIFF
--- a/tests/Application/config/packages/security.yaml
+++ b/tests/Application/config/packages/security.yaml
@@ -1,13 +1,14 @@
 parameters:
     sylius.security.admin_regex: "^/%sylius_admin.path_name%"
-    sylius.security.api_regex: "^/api"
-    sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|new-api|api/.*|api$|media/.*)[^/]++"
-    sylius.security.new_api_route: "/new-api"
+    sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|api/.*|api$|media/.*)[^/]++"
+    sylius.security.new_api_route: "/api/v2"
     sylius.security.new_api_regex: "^%sylius.security.new_api_route%"
     sylius.security.new_api_admin_route: "%sylius.security.new_api_route%/admin"
     sylius.security.new_api_admin_regex: "^%sylius.security.new_api_admin_route%"
     sylius.security.new_api_shop_route: "%sylius.security.new_api_route%/shop"
     sylius.security.new_api_shop_regex: "^%sylius.security.new_api_shop_route%"
+    sylius.security.new_api_user_account_route: "%sylius.security.new_api_shop_route%/account"
+    sylius.security.new_api_user_account_regex: "^%sylius.security.new_api_user_account_route%"
 
 security:
     always_authenticate_before_granting: true
@@ -20,9 +21,6 @@ security:
             id: sylius.shop_user_provider.email_or_name_based
         sylius_api_shop_user_provider:
             id: sylius.shop_user_provider.email_or_name_based
-        sylius_api_chain_provider:
-            chain:
-                providers: [sylius_api_shop_user_provider, sylius_api_admin_user_provider]
 
     encoders:
         Sylius\Component\User\Model\UserInterface: argon2i
@@ -55,12 +53,12 @@ security:
             anonymous: true
 
         new_api_admin_user:
-            pattern: "%sylius.security.new_api_route%/admin-user-authentication-token"
-            provider: sylius_admin_user_provider
+            pattern: "%sylius.security.new_api_admin_regex%/.*"
+            provider: sylius_api_admin_user_provider
             stateless: true
             anonymous: true
             json_login:
-                check_path: "%sylius.security.new_api_route%/admin-user-authentication-token"
+                check_path: "%sylius.security.new_api_admin_route%/authentication-token"
                 username_path: email
                 password_path: password
                 success_handler: lexik_jwt_authentication.handler.authentication_success
@@ -70,25 +68,16 @@ security:
                     - lexik_jwt_authentication.jwt_token_authenticator
 
         new_api_shop_user:
-            pattern: "%sylius.security.new_api_route%/shop-user-authentication-token"
-            provider: sylius_shop_user_provider
+            pattern: "%sylius.security.new_api_shop_regex%/.*"
+            provider: sylius_api_shop_user_provider
             stateless: true
             anonymous: true
             json_login:
-                check_path: "%sylius.security.new_api_route%/shop-user-authentication-token"
+                check_path: "%sylius.security.new_api_shop_route%/authentication-token"
                 username_path: email
                 password_path: password
                 success_handler: lexik_jwt_authentication.handler.authentication_success
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure
-            guard:
-                authenticators:
-                    - lexik_jwt_authentication.jwt_token_authenticator
-
-        new_api:
-            pattern: "%sylius.security.new_api_regex%/*"
-            provider: sylius_api_chain_provider
-            stateless: true
-            anonymous: lazy
             guard:
                 authenticators:
                     - lexik_jwt_authentication.jwt_token_authenticator
@@ -124,7 +113,11 @@ security:
             anonymous: true
 
         dev:
-            pattern:  ^/(_(profiler|wdt)|css|images|js)/
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+
+        image_resolver:
+            pattern: ^/media/cache/resolve
             security: false
 
     access_control:
@@ -134,15 +127,16 @@ security:
         - { path: "%sylius.security.shop_regex%/_partial", role: ROLE_NO_ACCESS }
 
         - { path: "%sylius.security.admin_regex%/login", role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: "%sylius.security.api_regex%/login", role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: "%sylius.security.shop_regex%/login", role: IS_AUTHENTICATED_ANONYMOUSLY }
 
         - { path: "%sylius.security.shop_regex%/register", role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: "%sylius.security.shop_regex%/verify", role: IS_AUTHENTICATED_ANONYMOUSLY }
 
         - { path: "%sylius.security.admin_regex%", role: ROLE_ADMINISTRATION_ACCESS }
-        - { path: "%sylius.security.api_regex%/.*", role: ROLE_API_ACCESS }
         - { path: "%sylius.security.shop_regex%/account", role: ROLE_USER }
 
         - { path: "%sylius.security.new_api_admin_regex%/.*", role: ROLE_API_ACCESS }
+        - { path: "%sylius.security.new_api_admin_route%/authentication-token", role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "%sylius.security.new_api_user_account_regex%/.*", role: ROLE_USER }
+        - { path: "%sylius.security.new_api_shop_route%/authentication-token", role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: "%sylius.security.new_api_shop_regex%/.*", role: IS_AUTHENTICATED_ANONYMOUSLY }


### PR DESCRIPTION
I found out that the security config is outdated in the skeleton. I updated it to the latest version found here: https://github.com/Sylius/Sylius-Standard/blob/master/config/packages/security.yaml

I noticed it by looking for the api route and saw that it was still `/new-api`, while Sylius moved to `/api/v2`.