### PR TITLE
[Maintenance] Bump up Sylius version to v1.11.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
             matrix:
                 php: ["8.0"]
                 symfony: ["5.4.*"]
-                sylius: ["^1.11"]
+                sylius: ["^1.11.2"]
                 node: ["14.x"]
                 mysql: ["8.0"]
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0",
-        "sylius/sylius": "^1.11"
+        "sylius/sylius": "^1.11.2"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",


### PR DESCRIPTION
Due to conflicts with `symfony/dependency-injection` and `symfony/framework-bundle` on Sylius, the newest Sylius version has not been installed, so I would like to bump up the minimum Sylius version.

Fixes #323 