### PR TITLE
Use Flex tool from setup-php action to lock Symfony version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
                 with:
                     php-version: "${{ matrix.php }}"
                     extensions: intl
-                    tools: symfony
+                    tools: flex,symfony
                     coverage: none
 
             -
@@ -92,12 +92,10 @@ jobs:
                         ${{ runner.os }}-php-${{ matrix.php }}-composer-
 
             -
-                name: Restrict Symfony version
-                if: matrix.symfony != ''
+                name: Configure global composer
                 run: |
                     composer global config --no-plugins allow-plugins.symfony/flex true
                     composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^1.10"
-                    composer config extra.symfony.require "${{ matrix.symfony }}"
 
             -
                 name: Restrict Sylius version
@@ -107,6 +105,8 @@ jobs:
             -
                 name: Install PHP dependencies
                 run: composer install --no-interaction
+                env:
+                    SYMFONY_REQUIRE: ${{ matrix.symfony }}
 
             -
                 name: Get Yarn cache directory


### PR DESCRIPTION
The `shivammathur/setup-php` action provides Flex as a global tool when setting up the environment.  So instead of installing it through an extra step, we can use the resources the action already provides.

Next, setting the `SYMFONY_REQUIRE` env var is the same as writing the `extra.symfony.require` key in `composer.json`.

All told, we can avoid a couple of extra Composer commands by using resources that are already available.  It's a minor optimization, but it's one nonetheless.