### PR TITLE
Cache provider fix

### DIFF
--- a/tests/Application/config/packages/prod/doctrine.yaml
+++ b/tests/Application/config/packages/prod/doctrine.yaml
@@ -1,26 +1,31 @@
 doctrine:
     orm:
-        metadata_cache_driver:
-            type: service
-            id: doctrine.system_cache_provider
-        query_cache_driver:
-            type: service
-            id: doctrine.system_cache_provider
-        result_cache_driver:
-            type: service
-            id: doctrine.result_cache_provider
+        entity_managers:
+            default:
+                metadata_cache_driver:
+                    type: service
+                    id: doctrine.system_cache_provider
+                query_cache_driver:
+                    type: service
+                    id: doctrine.system_cache_provider
+                result_cache_driver:
+                    type: service
+                    id: doctrine.result_cache_provider
 
 services:
     doctrine.result_cache_provider:
-        class: Symfony\Component\Cache\DoctrineProvider
+        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
         public: false
+        factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
         arguments:
             - '@doctrine.result_cache_pool'
     doctrine.system_cache_provider:
-        class: Symfony\Component\Cache\DoctrineProvider
+        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
         public: false
+        factory: [ 'Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap' ]
         arguments:
             - '@doctrine.system_cache_pool'
+
 
 framework:
     cache:

--- a/tests/Application/config/packages/test_cached/doctrine.yaml
+++ b/tests/Application/config/packages/test_cached/doctrine.yaml
@@ -2,15 +2,34 @@ doctrine:
     orm:
         entity_managers:
             default:
-                result_cache_driver:
-                    type: memcached
-                    host: localhost
-                    port: 11211
-                query_cache_driver:
-                    type: memcached
-                    host: localhost
-                    port: 11211
                 metadata_cache_driver:
-                    type: memcached
-                    host: localhost
-                    port: 11211
+                    type: service
+                    id: doctrine.system_cache_provider
+                query_cache_driver:
+                    type: service
+                    id: doctrine.system_cache_provider
+                result_cache_driver:
+                    type: service
+                    id: doctrine.result_cache_provider
+
+services:
+    doctrine.result_cache_provider:
+        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
+        public: false
+        factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
+        arguments:
+            - '@doctrine.result_cache_pool'
+    doctrine.system_cache_provider:
+        class: Doctrine\Common\Cache\Psr6\DoctrineProvider
+        public: false
+        factory: [ 'Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap' ]
+        arguments:
+            - '@doctrine.system_cache_pool'
+
+framework:
+    cache:
+        pools:
+            doctrine.result_cache_pool:
+                adapter: cache.app
+            doctrine.system_cache_pool:
+                adapter: cache.system


### PR DESCRIPTION
It looks like the plugin skeleton has an outdated doctrine configuration for the production and test_cached environment
Refs: #407 