### PR TITLE
Add postgres to depends in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
             - 80:80
         depends_on:
             - mysql
+#            - postgres
         networks:
             - sylius
 


### PR DESCRIPTION
Add `postgres` Docker compose service as an alternative dependency to the app.

Just to make it clear for newbies, who can get stuck on switching to Postgres via `docker-compose.yml` without noticing `app` Docker compose service dependency at first.