### PR TITLE
New dockerfile to use php 8.1

### DIFF
--- a/.docker/nginx/nginx.conf
+++ b/.docker/nginx/nginx.conf
@@ -38,7 +38,7 @@ http {
         location ~ \.php$ {
             include fastcgi_params;
 
-            fastcgi_pass unix:/var/run/php8-fpm.sock;
+            fastcgi_pass  127.0.0.1:9000;
             fastcgi_split_path_info ^(.+\.php)(/.*)$;
 
             fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;

--- a/.docker/php/php-fpm.conf 
+++ b/.docker/php/php-fpm.conf 
@@ -1,0 +1,29 @@
+[global]
+daemonize = no
+
+error_log = /var/log/php-fpm/error.log
+log_level = error
+
+[www]
+user  = www-data
+group = www-data
+
+clear_env = no
+
+catch_workers_output = yes
+
+slowlog = /var/log/php-fpm/slow.log
+
+listen = 127.0.0.1:9000
+listen.owner = www-data
+listen.group = www-data
+listen.mode  = 0660
+
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+pm.status_path = /status
+
+security.limit_extensions = .php

--- a/.docker/php/supervisord.conf
+++ b/.docker/php/supervisord.conf
@@ -1,0 +1,14 @@
+[supervisord]
+nodaemon = true
+user = root
+pidfile = /run/supervisord.pid
+
+[program:nginx]
+command = /usr/sbin/nginx
+user = root
+autostart = true
+
+[program:php-fpm]
+command = /usr/sbin/php-fpm
+user = root
+autostart = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,72 @@
+FROM node:14-alpine AS node
+FROM composer:2.3 AS composer
+
+FROM alpine:3.16.9
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+COPY --from=node /usr/lib           /usr/lib
+COPY --from=node /usr/local/share   /usr/local/share
+COPY --from=node /usr/local/lib     /usr/local/lib
+COPY --from=node /usr/local/include /usr/local/include
+COPY --from=node /usr/local/bin     /usr/local/bin
+
+RUN apk update --no-cache && apk add --no-cache \
+    curl \
+    supervisor \
+    unzip \
+    python3 \
+    g++ \
+    make \
+    nginx \
+    yarn \
+    php81 \
+    php81-apcu \
+    php81-calendar \
+    php81-common \
+    php81-cli \
+    php81-common \
+    php81-ctype \
+    php81-curl \
+    php81-dom \
+    php81-exif \
+    php81-fileinfo \
+    php81-fpm \
+    php81-gd \
+    php81-intl \
+    php81-mbstring \
+    php81-mysqli \
+    php81-mysqlnd \
+    php81-opcache \
+    php81-pdo \
+    php81-pdo_mysql \
+    php81-pdo_pgsql \
+    php81-pgsql \
+    php81-phar \
+    php81-session \
+    php81-simplexml \
+    php81-sqlite3 \
+    php81-tokenizer \
+    php81-xml \
+    php81-xmlwriter \
+    php81-xsl \
+    php81-zip
+
+RUN rm -rf /var/lib/apk/lists/* /tmp/* /var/tmp/* /usr/share/doc/* /usr/share/man/* /var/cache/apk/*
+
+RUN ln -s /usr/sbin/php-fpm81 /usr/sbin/php-fpm \
+    && ln -s /usr/bin/php81 /usr/bin/php \
+    && mkdir -p /run/php /var/log/php-fpm
+
+RUN adduser -u 1000 -D -S -G www-data www-data
+
+COPY .docker/php/supervisord.conf   /etc/supervisor/conf.d/supervisor.conf
+COPY .docker/nginx/nginx.conf         /etc/nginx/nginx.conf
+COPY .docker/php/php-fpm.conf       /etc/php81/php-fpm.conf
+COPY .docker/php/php.ini            /etc/php81/php.ini
+
+WORKDIR /app
+
+EXPOSE 80
+
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisor.conf"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     app:
-        image: sylius/standard:1.11-traditional-alpine
+        build: .
         environment:
             APP_ENV: "dev"
             DATABASE_URL: "mysql://root:mysql@mysql/sylius_%kernel.environment%?charset=utf8mb4"


### PR DESCRIPTION
Currently, the dockerfile does not allow you to have a php version higher than 8.0 and therefore to switch to sylius 1.13.