### PR TITLE
Remove password from default DATABASE_URL

### DIFF
--- a/tests/TestApplication/.env
+++ b/tests/TestApplication/.env
@@ -1,4 +1,4 @@
-DATABASE_URL=mysql://root:root@127.0.0.1/acme_sylius_example_plugin_%kernel.environment%
+DATABASE_URL=mysql://root@127.0.0.1/acme_sylius_example_plugin_%kernel.environment%
 
 BEHAT_BASE_URL="http://nginx/"
 


### PR DESCRIPTION
Removes the hardcoded password from the default `DATABASE_URL` in tests/TestApplication/.env.

Most local MySQL installations (Homebrew, fresh installs, Laravel Valet) use `root` without a password by default. The `root:root` pattern is less common and causes "Access denied" errors for developers starting with the skeleton.

This aligns with Sylius core and TestApplication which both use passwordless root.