### PR TITLE
Include bin/ in composer packages for rename script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,6 @@
 /.github export-ignore
 /.gitignore export-ignore
 /behat.yml.dist export-ignore
-/bin export-ignore
 /docker-compose.yml export-ignore
 /docs export-ignore
 /ecs.php export-ignore


### PR DESCRIPTION
The rename-plugin.php script is executed via post-create-project-cmd hook but was excluded from composer packages by .gitattributes, causing the script to fail when running `composer create-project`.