### PR TITLE
Bump Symfony requirement to ^7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,13 +35,13 @@
         "sylius-labs/suite-tags-extension": "~0.2",
         "sylius/sylius-rector": "^2.0",
         "sylius/test-application": "^2.0.0@alpha",
-        "symfony/browser-kit": "^6.4 || ^7.1",
-        "symfony/debug-bundle": "^6.4 || ^7.1",
-        "symfony/dotenv": "^6.4 || ^7.1",
-        "symfony/http-client": "^6.4 || ^7.1",
-        "symfony/intl": "^6.4 || ^7.1",
-        "symfony/runtime": "^6.4 || ^7.1",
-        "symfony/web-profiler-bundle": "^6.4 || ^7.1",
+        "symfony/browser-kit": "^6.4 || ^7.4",
+        "symfony/debug-bundle": "^6.4 || ^7.4",
+        "symfony/dotenv": "^6.4 || ^7.4",
+        "symfony/http-client": "^6.4 || ^7.4",
+        "symfony/intl": "^6.4 || ^7.4",
+        "symfony/runtime": "^6.4 || ^7.4",
+        "symfony/web-profiler-bundle": "^6.4 || ^7.4",
         "symfony/webpack-encore-bundle": "^2.2"
     },
     "config": {
@@ -59,7 +59,7 @@
             "dev-master": "2.0-dev"
         },
         "symfony": {
-            "require": "^6.4"
+            "require": "^7.4"
         },
         "public-dir": "vendor/sylius/test-application/public"
     },


### PR DESCRIPTION
Updates the `extra.symfony.require` constraint from `^6.4` to `^7.4`, allowing plugins created from this skeleton to use Symfony 7.4 components without automatic downgrading.