### PR TITLE
Include tests directory in composer create-project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,4 +15,3 @@
 /phpunit.xml.dist export-ignore
 /psalm.xml export-ignore
 /symfony.lock export-ignore
-/tests export-ignore


### PR DESCRIPTION
The `tests/` directory was excluded from `composer create-project` via `.gitattributes` export-ignore. This prevents plugin developers from getting:

- Example Behat contexts and test structure
- `tests/TestApplication/.env` with DATABASE_URL configuration
- Test fixtures and integration test examples

Since this skeleton is meant for development, the tests directory should be included to provide a complete starting point.