### PR TITLE
Include .gitignore in composer create-project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.github export-ignore
-/.gitignore export-ignore
 /behat.yml.dist export-ignore
 /docker-compose.yml export-ignore
 /docs export-ignore


### PR DESCRIPTION
Without .gitignore in the package, git doesn't know what to ignore and vendor/ gets committed when users initialize their repository.