### PR TITLE
Use BuildTestAppAction and migrate from Panther to Chrome session

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,32 @@ jobs:
                     - php: "8.3"
                       symfony: "^7.4"
                       sylius: "~2.2.0"
+                      database: "mysql:8.0"
+                      node: "22.x"
+                    - php: "8.3"
+                      symfony: "^7.4"
+                      sylius: "~2.2.0"
+                      database: "mariadb:10.11"
+                      node: "22.x"
+                    - php: "8.3"
+                      symfony: "^7.4"
+                      sylius: "~2.2.0"
+                      database: "mariadb:11.4"
+                      node: "22.x"
+                    - php: "8.3"
+                      symfony: "^7.4"
+                      sylius: "~2.2.0"
+                      database: "postgres:15"
+                      node: "22.x"
+                    - php: "8.3"
+                      symfony: "^7.4"
+                      sylius: "~2.2.0"
                       database: "postgres:16"
+                      node: "22.x"
+                    - php: "8.3"
+                      symfony: "^7.4"
+                      sylius: "~2.2.0"
+                      database: "postgres:17"
                       node: "22.x"
 
         env:
@@ -54,30 +79,13 @@ jobs:
                 uses: actions/checkout@v4
 
             -
-                name: Parse database string
-                run: |
-                    DB_TYPE="${DATABASE%%:*}"
-                    DB_VERSION="${DATABASE##*:}"
-                    echo "DB_TYPE=$DB_TYPE" >> $GITHUB_ENV
-                    echo "DB_VERSION=$DB_VERSION" >> $GITHUB_ENV
-
-                    if [ "$DB_TYPE" = "postgres" ]; then
-                        echo "DATABASE_URL=pgsql://postgres:postgres@127.0.0.1/sylius?serverVersion=$DB_VERSION" >> $GITHUB_ENV
-                    else
-                        echo "DATABASE_URL=mysql://root:root@127.0.0.1/sylius?serverVersion=$DB_VERSION" >> $GITHUB_ENV
-                    fi
-                env:
-                    DATABASE: ${{ matrix.database }}
-
-            -
                 name: Build Sylius Test Application
-                uses: SyliusLabs/BuildTestAppAction@v3.2.0
+                uses: SyliusLabs/BuildTestAppAction@v4
                 with:
                     e2e_js: "yes"
                     cache_key: "${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}"
                     cache_restore_key: "${{ runner.os }}-php-${{ matrix.php }}-composer-"
-                    database: "${{ env.DB_TYPE }}"
-                    database_version: "${{ env.DB_VERSION }}"
+                    database: "${{ matrix.database }}"
                     node_version: "${{ matrix.node }}"
                     php_version: "${{ matrix.php }}"
                     sylius_version: "${{ matrix.sylius }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,11 @@ on:
     push:
         branches-ignore:
             - 'dependabot/**'
-    pull_request: ~
+        paths-ignore:
+            - "*.md"
+    pull_request:
+        paths-ignore:
+            - "*.md"
     release:
         types: [created]
     schedule:
@@ -12,132 +16,65 @@ on:
             cron: "0 1 * * 6" # Run at 1am every Saturday
     workflow_dispatch: ~
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     tests:
         runs-on: ubuntu-latest
 
-        name: "Sylius ${{ matrix.sylius }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
+        name: "Sylius ${{ matrix.sylius }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, ${{ matrix.database }}"
 
         strategy:
             fail-fast: false
             matrix:
                 php: ["8.3"]
-                symfony: ["^6.4", "^7.3"]
+                symfony: ["^6.4", "~7.3.0"]
                 sylius: ["~2.0.0", "~2.1.0"]
+                database: ["mysql:8.4"]
                 node: ["22.x"]
-                mysql: ["8.4"]
 
         env:
             APP_ENV: test
-            BEHAT_BASE_URL: "http://127.0.0.1:8080/"
-            DATABASE_URL: "mysql://root:root@127.0.0.1/sylius?serverVersion=${{ matrix.mysql }}"
 
         steps:
             -
                 uses: actions/checkout@v4
 
             -
-                name: Setup PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: "${{ matrix.php }}"
-                    extensions: intl
-                    tools: flex, symfony
-                    coverage: none
-
-            -
-                name: Setup Node
-                uses: actions/setup-node@v4
-                with:
-                    node-version: "${{ matrix.node }}"
-
-            -
-                name: Shutdown default MySQL
-                run: sudo service mysql stop
-
-            -
-                name: Setup MySQL
-                uses: mirromutth/mysql-action@v1.1
-                with:
-                    mysql version: "${{ matrix.mysql }}"
-                    mysql root password: "root"
-
-            -
-                name: Output PHP version for Symfony CLI
-                run: php -v | head -n 1 | awk '{ print $2 }' > .php-version
-
-            -
-                name: Get Composer cache directory
-                id: composer-cache
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            -
-                name: Cache Composer
-                uses: actions/cache@v4
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json **/composer.lock') }}
-                    restore-keys: |
-                        ${{ runner.os }}-php-${{ matrix.php }}-composer-
-
-            -
-                name: Restrict Symfony version
-                if: matrix.symfony != ''
+                name: Parse database string
                 run: |
-                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^2.4"
-                    composer global config --no-plugins allow-plugins.symfony/flex true
-                    composer config extra.symfony.require "${{ matrix.symfony }}"
+                    DB_TYPE="${DATABASE%%:*}"
+                    DB_VERSION="${DATABASE##*:}"
+                    echo "DB_TYPE=$DB_TYPE" >> $GITHUB_ENV
+                    echo "DB_VERSION=$DB_VERSION" >> $GITHUB_ENV
+
+                    if [ "$DB_TYPE" = "postgres" ]; then
+                        echo "DATABASE_URL=pgsql://postgres:postgres@127.0.0.1/sylius?serverVersion=$DB_VERSION" >> $GITHUB_ENV
+                    else
+                        echo "DATABASE_URL=mysql://root:root@127.0.0.1/sylius?serverVersion=$DB_VERSION" >> $GITHUB_ENV
+                    fi
+                env:
+                    DATABASE: ${{ matrix.database }}
 
             -
-                name: Restrict Sylius version
-                if: matrix.sylius != ''
-                run: composer require "sylius/sylius:${{ matrix.sylius }}" --no-update --no-scripts --no-interaction
-
-            -
-                name: Install PHP dependencies
-                run: composer install --no-interaction
+                name: Build Sylius Test Application
+                uses: SyliusLabs/BuildTestAppAction@v3.2.0
+                with:
+                    e2e_js: "yes"
+                    cache_key: "${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}"
+                    cache_restore_key: "${{ runner.os }}-php-${{ matrix.php }}-composer-"
+                    database: "${{ env.DB_TYPE }}"
+                    database_version: "${{ env.DB_VERSION }}"
+                    node_version: "${{ matrix.node }}"
+                    php_version: "${{ matrix.php }}"
+                    sylius_version: "${{ matrix.sylius }}"
+                    symfony_version: "${{ matrix.symfony }}"
 
             -
                 name: Run unit tests
                 run: vendor/bin/phpunit --colors=always --testsuite=unit
-
-            -
-                name: Get Yarn cache directory
-                id: yarn-cache
-                run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-            -
-                name: Cache Yarn
-                uses: actions/cache@v4
-                with:
-                    path: ${{ steps.yarn-cache.outputs.dir }}
-                    key: ${{ runner.os }}-node-${{ matrix.node }}-yarn-${{ hashFiles('**/package.json **/yarn.lock') }}
-                    restore-keys: |
-                        ${{ runner.os }}-node-${{ matrix.node }}-yarn-
-
-            -
-                name: Install JS dependencies
-                run: (cd vendor/sylius/test-application && yarn install)
-
-            -
-                name: Prepare test application database
-                run: |
-                    (vendor/bin/console doctrine:database:create -vvv)
-                    (vendor/bin/console doctrine:schema:create -vvv)
-
-            -
-                name: Prepare test application assets
-                run: |
-                    vendor/bin/console assets:install -vvv
-                    (cd vendor/sylius/test-application && yarn build)
-
-            -
-                name: Prepare test application cache
-                run: vendor/bin/console cache:warmup -vvv
-
-            -
-                name: Load fixtures in test application
-                run: vendor/bin/console sylius:fixtures:load -n
 
             -
                 name: Validate composer.json
@@ -150,14 +87,6 @@ jobs:
             -
                 name: Run Non-unit PHPUnit tests
                 run: vendor/bin/phpunit --colors=always --testsuite=non-unit
-
-            -
-                name: Run Chrome Headless
-                run: google-chrome-stable --enable-automation --disable-background-networking --no-default-browser-check --no-first-run --disable-popup-blocking --disable-default-apps --allow-insecure-localhost --disable-translate --disable-extensions --no-sandbox --enable-features=Metal --headless --remote-debugging-port=9222 --window-size=2880,1800 --proxy-server='direct://' --proxy-bypass-list='*' http://127.0.0.1 > /dev/null 2>&1 &
-
-            -
-                name: Run webserver
-                run: symfony server:start --port=8080 --no-tls --daemon
 
             -
                 name: Run Behat

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,10 +30,21 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["8.3"]
-                symfony: ["^6.4", "~7.3.0"]
-                sylius: ["~2.0.0", "~2.1.0"]
+                symfony: ["^6.4", "^7.4"]
+                sylius: ["~2.0.0", "~2.1.0", "~2.2.0"]
                 database: ["mysql:8.4"]
                 node: ["22.x"]
+
+                exclude:
+                    - sylius: "~2.0.0"
+                      symfony: "^7.4"
+
+                include:
+                    - php: "8.3"
+                      symfony: "^7.4"
+                      sylius: "~2.2.0"
+                      database: "postgres:16"
+                      node: "22.x"
 
         env:
             APP_ENV: test
@@ -97,7 +108,7 @@ jobs:
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Behat logs - ${{ matrix.sylius }}-${{ github.run_id }}-${{ github.run_number }}"
+                    name: "Behat logs - Sylius ${{ matrix.sylius }} - ${{ matrix.database }} - ${{ github.run_id }}"
                     path: etc/build/
                     if-no-files-found: ignore
                     compression-level: 6

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -11,7 +11,6 @@ default:
 
     extensions:
         DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
-        Robertfausk\Behat\PantherExtension: ~
 
         FriendsOfBehat\MinkDebugExtension:
             directory: etc/build
@@ -22,7 +21,7 @@ default:
             files_path: "%paths.base%/vendor/sylius/sylius/src/Sylius/Behat/Resources/fixtures/"
             base_url: "%env(BEHAT_BASE_URL)%"
             default_session: symfony
-            javascript_session: panther
+            javascript_session: chrome
             sessions:
                 symfony:
                     symfony: ~
@@ -30,36 +29,6 @@ default:
                     chrome:
                         api_url: http://127.0.0.1:9222
                         validate_certificate: false
-                panther:
-                    panther:
-                        manager_options:
-                            connection_timeout_in_ms: 5000
-                            request_timeout_in_ms: 120000
-                            chromedriver_arguments:
-                                - --log-path=etc/build/chromedriver.log
-                                - --verbose
-                            capabilities:
-                                acceptSslCerts: true
-                                acceptInsecureCerts: true
-                                unexpectedAlertBehaviour: accept
-                        options:
-                            webServerDir: '%paths.base%/vendor/sylius/test-application/public'
-                            browser_arguments:
-                                - --window-size=1200,1000
-                                - --headless
-                                - --no-sandbox
-                                - --disable-dev-shm-usage
-                                - --disable-gpu
-                                - --disable-infobars
-                                - --disable-features=TranslateUI
-                                - --disable-translate
-                                - --disable-popup-blocking
-                                - --disable-blink-features=AutomationControlled
-                                - --disable-component-extensions-with-background-pages
-                                - --disable-background-networking
-                                - --disable-dev-tools
-                                - --disable-extensions
-                                - --disable-password-manager-leak-detection
             show_auto: false
 
         FriendsOfBehat\SymfonyExtension:

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "phpstan/phpstan-doctrine": "^1.3",
         "phpstan/phpstan-webmozart-assert": "^1.2",
         "phpunit/phpunit": "^10.5",
-        "robertfausk/behat-panther-extension": "^1.1",
         "sylius-labs/coding-standard": "^4.4",
         "sylius-labs/suite-tags-extension": "~0.2",
         "sylius/sylius-rector": "^2.0",

--- a/tests/TestApplication/.env
+++ b/tests/TestApplication/.env
@@ -1,6 +1,6 @@
 DATABASE_URL=mysql://root@127.0.0.1/acme_sylius_example_plugin_%kernel.environment%
 
-BEHAT_BASE_URL="http://nginx/"
+BEHAT_BASE_URL="http://127.0.0.1:8080/"
 
 SYLIUS_TEST_APP_BUNDLES_PATH="tests/TestApplication/config/bundles.php"
 SYLIUS_TEST_APP_CONFIGS_TO_IMPORT="@AcmeSyliusExamplePlugin/tests/TestApplication/config/config.yaml"


### PR DESCRIPTION
## Summary

- Replace Panther with Chrome session for Behat (simpler, no port conflicts)
- Use new `SyliusLabs/BuildTestAppAction@v4` for CI workflow
- Change `BEHAT_BASE_URL` from nginx to standard `http://127.0.0.1:8080/`
- Make `base_url` configurable via env var
- Test all LTS databases: MySQL 8.0/8.4, MariaDB 10.11/11.4, PostgreSQL 15/16/17

Related: https://github.com/SyliusLabs/BuildTestAppAction/pull/19